### PR TITLE
complex: improve scanning, parsing and code generation

### DIFF
--- a/comp/compiler.go
+++ b/comp/compiler.go
@@ -764,14 +764,14 @@ func (c *Compiler) generate(tokens goparser.Tokens) (err error) {
 			c.emit(t, vm.GetGlobal, di)
 
 		case lang.Imag:
-			f, err := strconv.ParseComplex(t.Str, 64)
+			f, err := strconv.ParseComplex(t.Str, 128)
 			if err != nil {
 				return err
 			}
 			v := vm.ValueOf(f)
 			di := len(c.Data)
 			c.Data = append(c.Data, v)
-			push(&symbol.Symbol{Kind: symbol.Const, Value: v, Type: c.Symbols["complex128"].Type})
+			push(&symbol.Symbol{Kind: symbol.Const, Value: v, Cval: litCval(t.Str, token.IMAG), Type: c.Symbols["complex128"].Type})
 			c.emit(t, vm.GetGlobal, di)
 
 		case lang.String:
@@ -2767,15 +2767,25 @@ func arithmeticOpType(right, left *symbol.Symbol) *vm.Type {
 	if left.Kind == symbol.Const && right.Kind != symbol.Const {
 		return symbol.Vtype(right)
 	}
-	// Both constants (or both non-const): pick the wider numeric type (float > int per Go spec).
+	// Both constants (or both non-const): pick the wider numeric type.
 	rt, lt := symbol.Vtype(right), symbol.Vtype(left)
 	if rt != nil && lt != nil {
-		rk, lk := rt.Rtype.Kind(), lt.Rtype.Kind()
-		if (lk == reflect.Float32 || lk == reflect.Float64) && rk != reflect.Float32 && rk != reflect.Float64 {
+		if numericRank(lt) > numericRank(rt) {
 			return lt
 		}
 	}
 	return rt
+}
+
+func numericRank(typ *vm.Type) int {
+	// Per Go spec, complex > float > int.
+	switch typ.Rtype.Kind() {
+	case reflect.Complex64, reflect.Complex128:
+		return 2
+	case reflect.Float32, reflect.Float64:
+		return 1
+	}
+	return 0
 }
 
 func constKind(right, left *symbol.Symbol) symbol.Kind {

--- a/goparser/decl.go
+++ b/goparser/decl.go
@@ -558,6 +558,10 @@ func constValue(c constant.Value) any {
 	case constant.Float:
 		v, _ := constant.Float64Val(c)
 		return v
+	case constant.Complex:
+		re, _ := constant.Float64Val(constant.Real(c))
+		im, _ := constant.Float64Val(constant.Imag(c))
+		return complex(re, im)
 	}
 	return nil
 }
@@ -579,6 +583,8 @@ func DefaultConstType(c constant.Value, syms symbol.SymMap) *vm.Type {
 		name = "int"
 	case constant.Float:
 		name = "float64"
+	case constant.Complex:
+		name = "complex128"
 	case constant.String:
 		name = "string"
 	case constant.Bool:

--- a/interp/interpreter_test.go
+++ b/interp/interpreter_test.go
@@ -3583,6 +3583,17 @@ func TestBuiltin(t *testing.T) {
 		{n: "complex128_lit_err2", skip: true, src: `complex(12,int(34))`, err: "invalid argument: type int, expected floating-point"},
 		{n: "complex128_lit_err3", skip: true, src: `complex(float32(12),float64(34))`, err: "invalid operation: mismatched types float32 and float64"},
 		{n: "complex128_lit_err4", src: `complex(12, "34")`, err: "invalid argument: type string, expected floating-point"}, // FIXME(sbinet): compiled Go has different error string.
+
+		{n: "complex_lit_add", src: `1 + 2i`, res: "(1+2i)"},
+		{n: "complex_lit_sub", src: `(1+2i) - (3+4i)`, res: "(-2-2i)"},
+		{n: "complex_lit_mul", src: `(1+2i) * (3-4i)`, res: "(11+2i)"},
+		{n: "complex_lit_neg", src: `-(1+2i)`, res: "(-1-2i)"},
+		{n: "complex_lit_conv64", src: `complex64(1+2i)`, res: "(1+2i)"},
+		{n: "complex_lit_wide_im", src: `1e10 + 1.11e100i`, res: "(1e+10+1.11e+100i)"},
+		{n: "float_trailing_dot", src: `11.`, res: "11"},
+		{n: "float_trailing_dot_neg", src: `-11.`, res: "-11"},
+		{n: "float_trailing_dot_add", src: `11. + 1`, res: "12"},
+		{n: "float_trailing_dot_complex", src: `-11. + 7e+1i`, res: "(-11+70i)"},
 	})
 }
 

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -348,19 +348,19 @@ func (sc *Scanner) getNum(src string) (s string, tok lang.Token) {
 		case isNum(r):
 			// ok
 		case r == '.' && !hasDot && !hasExp:
-			// Check this is not a method call (e.g. 123.String()). In a hex
-			// float the fractional part may use hex digits (e.g. 0x1.fp3).
+			// Disambiguate 123. from a selector 123.String()).
+			// In a hex float the fractional part may use hex digits:  0x1.fp3.
 			var next byte
 			if i+1 < len(src) {
 				next = src[i+1]
 			}
 			hexFrac := isHex && ((next >= 'a' && next <= 'f') || (next >= 'A' && next <= 'F'))
-			if i+1 < len(src) && (isNum(rune(next)) || hexFrac) {
-				hasDot = true
-				tok = lang.Float
-			} else {
+			isSelector := !hexFrac && ((next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z') || next == '_')
+			if isSelector {
 				return src[:i], tok
 			}
+			hasDot = true
+			tok = lang.Float
 		case r == '.' && i == 0 && hasDot:
 			// Leading dot already accounted for.
 		case (r == 'e' || r == 'E') && !hasExp && !isHex:


### PR DESCRIPTION
### Summary

With these changes, at least "mvm test fmt" doesn't panic anymore on complex number formats.

Use go/constant to perform constant folding on arithmetic expressions involving complex.

This is still preliminary work to complex dedicated opcodes.

<!--
Thanks for sending a PR! Please fill in the sections below.
-->

### Tests

```console
$ mvm -e '1+2i'
(1+2i)
```
<!--
- For a bug fix: a `_samples/*.go` or `interp` test case that fails on
  main and passes here.
- For a new feature: tests that exercise the happy path and at least
  one error path.
- For a refactor with no behavior change: say so.
-->

### Checklist

- [x] `make test` passes
- [x] `make lint` passes
- [ ] If language-spec or stdlib-binding behavior changed, the relevant
      `docs/modules/*.md` or ADR is updated
